### PR TITLE
Added ability to modify fetch headers on subsequent requests

### DIFF
--- a/dist/fetch-retry.umd.js
+++ b/dist/fetch-retry.umd.js
@@ -26,10 +26,15 @@
       throw new ArgumentError('retryOn property expects an array or function');
     }
 
+    if (defaults.retryHeaders !== undefined && typeof defaults.retryHeaders !== 'object' && typeof defaults.retryHeaders !== 'function) {
+      throw new ArgumentError('retryHeaders property expects an object or function');
+    }
+
     var baseDefaults = {
       retries: 3,
       retryDelay: 1000,
       retryOn: [],
+      retryHeaders: {},
     };
 
     defaults = Object.assign(baseDefaults, defaults);
@@ -38,6 +43,7 @@
       var retries = defaults.retries;
       var retryDelay = defaults.retryDelay;
       var retryOn = defaults.retryOn;
+      var retryHeaders = defaults.retryHeaders;
 
       if (init && init.retries !== undefined) {
         if (isPositiveInteger(init.retries)) {
@@ -63,6 +69,14 @@
         }
       }
 
+      if (init && init.retryHeaders) {
+        if (typeof init.retryHeaders === 'object') || (typeof init.retryHeaders === 'function')) {
+          retryHeaders = init.retryHeaders;
+        } else {
+          throw new ArgumentError('retryHeaders property expects an object or function');
+        }
+      }
+      
       // eslint-disable-next-line no-undef
       return new Promise(function (resolve, reject) {
         var wrappedFetch = function (attempt) {
@@ -127,6 +141,11 @@
         function retry(attempt, error, response) {
           var delay = (typeof retryDelay === 'function') ?
             retryDelay(attempt, error, response) : retryDelay;
+          var newHeaders = (typeof retryHeaders === 'function') ?
+            retryHeaders(attempt, error, response) : retryHeaders;
+          if (newHeaders && typeof newHeaders === 'object') {
+            init = {...init, headers: { ...init.headers, ...newHeaders } };
+          }
           setTimeout(function () {
             wrappedFetch(++attempt);
           }, delay);

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,17 @@ declare module 'fetch-retry' {
     response: Awaited<ReturnType<F>> | null,
   ) => boolean | Promise<boolean>;
 
+  export type RequestRetryHeadersFunction<F extends FetchLibrary> = (
+    attempt: number,
+    error: Error | null,
+    response: Awaited<ReturnType<F>> | null,
+  ) => { [key: string]: string }
+
   export type RequestInitRetryParams<F extends FetchLibrary> = {
     retries?: number;
     retryDelay?: number | RequestDelayFunction<F>;
     retryOn?: number[] | RequestRetryOnFunction<F>;
+    retryHeaders?: { [key: string]: string } | RequestRetryHeadersFunction<F>;
   };
 
   export type RequestInitWithRetry<F extends FetchLibrary> = Parameters<F>[1] &

--- a/index.js
+++ b/index.js
@@ -22,10 +22,15 @@ module.exports = function (fetch, defaults) {
     throw new ArgumentError('retryOn property expects an array or function');
   }
 
+  if (defaults.retryHeaders !== undefined && typeof defaults.retryHeaders !== 'object' && typeof defaults.retryHeaders !== 'function) {
+    throw new ArgumentError('retryHeaders property expects an object or function');
+  }
+
   var baseDefaults = {
     retries: 3,
     retryDelay: 1000,
     retryOn: [],
+    retryHeaders: {},
   };
 
   defaults = Object.assign(baseDefaults, defaults);
@@ -34,6 +39,7 @@ module.exports = function (fetch, defaults) {
     var retries = defaults.retries;
     var retryDelay = defaults.retryDelay;
     var retryOn = defaults.retryOn;
+    var retryHeaders = defaults.retryHeaders;
 
     if (init && init.retries !== undefined) {
       if (isPositiveInteger(init.retries)) {
@@ -56,6 +62,14 @@ module.exports = function (fetch, defaults) {
         retryOn = init.retryOn;
       } else {
         throw new ArgumentError('retryOn property expects an array or function');
+      }
+    }
+
+    if (init && init.retryHeaders) {
+      if (typeof init.retryHeaders === 'object' || (typeof init.retryHeaders === 'function')) {
+        retryHeaders = init.retryHeaders;
+      } else {
+        throw new ArgumentError('retryHeaders property expects an object or function');
       }
     }
 
@@ -123,6 +137,11 @@ module.exports = function (fetch, defaults) {
       function retry(attempt, error, response) {
         var delay = (typeof retryDelay === 'function') ?
           retryDelay(attempt, error, response) : retryDelay;
+        var newHeaders = (typeof retryHeaders === 'function') ?
+          retryHeaders(attempt, error, response) : retryHeaders;
+        if (newHeaders && typeof newHeaders === 'object') {
+          init = {...init, headers: { ...init.headers, ...newHeaders } };
+        }
         setTimeout(function () {
           wrappedFetch(++attempt);
         }, delay);


### PR DESCRIPTION
In same cases, like Supabase Client fetch()'s it makes sense to modify headers on requests.

For example, when calling Edge Function endpoints, if we get timeout/routing errors like 502 Bad Gateway this might mean that a certain Region is down. In such cases it might make sense to set the X-Region header to a random Supabase Edge Function region to allow cycling through some good options to make sure one that is up is found.